### PR TITLE
Fix notation in documentation of volatility function

### DIFF
--- a/R/volatility.R
+++ b/R/volatility.R
@@ -23,7 +23,7 @@
 #'
 #'\itemize{ 
 #'\item Close-to-Close Volatility (\code{calc="close"})\cr
-#'\deqn{ \sigma_{cl} = \sqrt{\frac{Z}{n-2} \sum_{i=1}^{n-1}(r_i-\bar{r})^2}
+#'\deqn{ \sigma_{cl} = \sqrt{\frac{N}{n-2} \sum_{i=1}^{n-1}(r_i-\bar{r})^2}
 #'}{sqrt(N) * runSD(ROC(Cl), n-1)}
 #'\deqn{where\;\; r_i = \log \left(\frac{C_i}{C_{i-1}}\right) }{}
 #'\deqn{and\;\; \bar{r} = \frac{r_1+r_2+\ldots +r_{n-1}}{n-1} }{}
@@ -33,7 +33,7 @@
 #'Brownian motion with zero drift and no opening jumps (i.e. the opening =
 #'close of the previous period). This estimator is 7.4 times more efficient
 #'than the close-to-close estimator.\cr
-#'\deqn{ \sigma = \sqrt{ \frac{Z}{n} \sum
+#'\deqn{ \sigma = \sqrt{ \frac{N}{n} \sum
 #'  \left[ \textstyle\frac{1}{2}\displaystyle
 #'    \left( \log \frac{H_i}{L_i} \right)^2  - (2\log 2-1)
 #'    \left( \log \frac{C_i}{O_i} \right)^2 \right] }
@@ -43,14 +43,14 @@
 #'\item High-Low Volatility: Parkinson (\code{calc="parkinson"})\cr 
 #'The Parkinson formula for estimating the historical volatility of 
 #'an underlying based on high and low prices.\cr
-#'\deqn{ \sigma = \sqrt{ \frac{Z}{4 n \times \log 2} \sum_{i=1}^{n}
+#'\deqn{ \sigma = \sqrt{ \frac{N}{4 n \times \log 2} \sum_{i=1}^{n}
 #'  \left(\log \frac{H_i}{L_i}\right)^2}
 #'}{sqrt(N/(4*n*log(2)) * runSum(log(Hi/Lo)^2, n))}
 #'
 #'\item OHLC Volatility: Rogers and Satchell (\code{calc="rogers.satchell"})\cr
 #'The Roger and Satchell historical volatility estimator allows for non-zero
 #'drift, but assumed no opening jump.\cr
-#'\deqn{ \sigma = \sqrt{ \textstyle\frac{Z}{n} \sum \left[
+#'\deqn{ \sigma = \sqrt{ \textstyle\frac{N}{n} \sum \left[
 #'  \log \textstyle\frac{H_i}{C_i} \times \log \textstyle\frac{H_i}{O_i} +
 #'  \log \textstyle\frac{L_i}{C_i} \times \log \textstyle\frac{L_i}{O_i} \right] }
 #'}{sqrt(N/n * runSum(log(Hi/Cl) * log(Hi/Op) +
@@ -59,7 +59,7 @@
 #'\item OHLC Volatility: Garman and Klass - Yang and Zhang
 #'(\code{calc="gk.yz"})\cr This estimator is a modified version of the Garman
 #'and Klass estimator that allows for opening gaps.\cr
-#'\deqn{ \sigma = \sqrt{ \textstyle\frac{Z}{n} \sum \left[
+#'\deqn{ \sigma = \sqrt{ \textstyle\frac{N}{n} \sum \left[
 #'  \left( \log \textstyle\frac{O_i}{C_{i-1}} \right)^2  +
 #'    \textstyle\frac{1}{2}\displaystyle
 #'  \left( \log \textstyle\frac{H_i}{L_i} \right)^2 - (2 \times \log 2-1)
@@ -79,15 +79,15 @@
 #'ignored, if both are provided.\cr
 #'\deqn{ \sigma^2 = \sigma_o^2 + k\sigma_c^2 + (1-k)\sigma_{rs}^2
 #'}{ s <- sqrt(s2o + k*s2c + (1-k)*(s2rs^2)) }
-#'\deqn{ \sigma_o^2 =\textstyle \frac{Z}{n-1} \sum
+#'\deqn{ \sigma_o^2 =\textstyle \frac{N}{n-1} \sum
 #'  \left( \log \frac{O_i}{C_{i-1}}-\mu_o \right)^2
 #'}{ s2o <- N * runVar(log(Op/lag(Cl,1)), n=n) }
 #'\deqn{ \mu_o=\textstyle \frac{1}{n} \sum \log \frac{O_i}{C_{i-1}} }{}
-#'\deqn{ \sigma_c^2 =\textstyle \frac{Z}{n-1} \sum
+#'\deqn{ \sigma_c^2 =\textstyle \frac{N}{n-1} \sum
 #'  \left( \log \frac{C_i}{O_i}-\mu_c \right)^2
 #'}{ s2c <- N * runVar(log(Cl/Op), n=n) }
 #'\deqn{ \mu_c=\textstyle \frac{1}{n} \sum \log \frac{C_i}{O_i} }{}
-#'\deqn{ \sigma_{rs}^2 = \textstyle\frac{Z}{n} \sum \left( 
+#'\deqn{ \sigma_{rs}^2 = \textstyle\frac{N}{n} \sum \left(
 #'  \log \textstyle\frac{H_i}{C_i} \times \log \textstyle\frac{H_i}{O_i} + 
 #'  \log \textstyle\frac{L_i}{C_i} \times \log \textstyle\frac{L_i}{O_i} 
 #'  \right)

--- a/man/volatility.Rd
+++ b/man/volatility.Rd
@@ -35,7 +35,7 @@ Selected volatility estimators/indicators; various authors.
 \details{
 \itemize{ 
 \item Close-to-Close Volatility (\code{calc="close"})\cr
-\deqn{ \sigma_{cl} = \sqrt{\frac{Z}{n-2} \sum_{i=1}^{n-1}(r_i-\bar{r})^2}
+\deqn{ \sigma_{cl} = \sqrt{\frac{N}{n-2} \sum_{i=1}^{n-1}(r_i-\bar{r})^2}
 }{sqrt(N) * runSD(ROC(Cl), n-1)}
 \deqn{where\;\; r_i = \log \left(\frac{C_i}{C_{i-1}}\right) }{}
 \deqn{and\;\; \bar{r} = \frac{r_1+r_2+\ldots +r_{n-1}}{n-1} }{}
@@ -45,7 +45,7 @@ Garman and Klass estimator for estimating historical volatility assumes
 Brownian motion with zero drift and no opening jumps (i.e. the opening =
 close of the previous period). This estimator is 7.4 times more efficient
 than the close-to-close estimator.\cr
-\deqn{ \sigma = \sqrt{ \frac{Z}{n} \sum
+\deqn{ \sigma = \sqrt{ \frac{N}{n} \sum
  \left[ \textstyle\frac{1}{2}\displaystyle
    \left( \log \frac{H_i}{L_i} \right)^2  - (2\log 2-1)
    \left( \log \frac{C_i}{O_i} \right)^2 \right] }
@@ -55,14 +55,14 @@ than the close-to-close estimator.\cr
 \item High-Low Volatility: Parkinson (\code{calc="parkinson"})\cr 
 The Parkinson formula for estimating the historical volatility of 
 an underlying based on high and low prices.\cr
-\deqn{ \sigma = \sqrt{ \frac{Z}{4 n \times \log 2} \sum_{i=1}^{n}
+\deqn{ \sigma = \sqrt{ \frac{N}{4 n \times \log 2} \sum_{i=1}^{n}
  \left(\log \frac{H_i}{L_i}\right)^2}
 }{sqrt(N/(4*n*log(2)) * runSum(log(Hi/Lo)^2, n))}
 
 \item OHLC Volatility: Rogers and Satchell (\code{calc="rogers.satchell"})\cr
 The Roger and Satchell historical volatility estimator allows for non-zero
 drift, but assumed no opening jump.\cr
-\deqn{ \sigma = \sqrt{ \textstyle\frac{Z}{n} \sum \left[
+\deqn{ \sigma = \sqrt{ \textstyle\frac{N}{n} \sum \left[
  \log \textstyle\frac{H_i}{C_i} \times \log \textstyle\frac{H_i}{O_i} +
  \log \textstyle\frac{L_i}{C_i} \times \log \textstyle\frac{L_i}{O_i} \right] }
 }{sqrt(N/n * runSum(log(Hi/Cl) * log(Hi/Op) +
@@ -71,7 +71,7 @@ drift, but assumed no opening jump.\cr
 \item OHLC Volatility: Garman and Klass - Yang and Zhang
 (\code{calc="gk.yz"})\cr This estimator is a modified version of the Garman
 and Klass estimator that allows for opening gaps.\cr
-\deqn{ \sigma = \sqrt{ \textstyle\frac{Z}{n} \sum \left[
+\deqn{ \sigma = \sqrt{ \textstyle\frac{N}{n} \sum \left[
  \left( \log \textstyle\frac{O_i}{C_{i-1}} \right)^2  +
    \textstyle\frac{1}{2}\displaystyle
  \left( \log \textstyle\frac{H_i}{L_i} \right)^2 - (2 \times \log 2-1)
@@ -91,15 +91,15 @@ Users may override the default values of \eqn{\alpha} (1.34 by default) or
 ignored, if both are provided.\cr
 \deqn{ \sigma^2 = \sigma_o^2 + k\sigma_c^2 + (1-k)\sigma_{rs}^2
 }{ s <- sqrt(s2o + k*s2c + (1-k)*(s2rs^2)) }
-\deqn{ \sigma_o^2 =\textstyle \frac{Z}{n-1} \sum
+\deqn{ \sigma_o^2 =\textstyle \frac{N}{n-1} \sum
  \left( \log \frac{O_i}{C_{i-1}}-\mu_o \right)^2
 }{ s2o <- N * runVar(log(Op/lag(Cl,1)), n=n) }
 \deqn{ \mu_o=\textstyle \frac{1}{n} \sum \log \frac{O_i}{C_{i-1}} }{}
-\deqn{ \sigma_c^2 =\textstyle \frac{Z}{n-1} \sum
+\deqn{ \sigma_c^2 =\textstyle \frac{N}{n-1} \sum
  \left( \log \frac{C_i}{O_i}-\mu_c \right)^2
 }{ s2c <- N * runVar(log(Cl/Op), n=n) }
 \deqn{ \mu_c=\textstyle \frac{1}{n} \sum \log \frac{C_i}{O_i} }{}
-\deqn{ \sigma_{rs}^2 = \textstyle\frac{Z}{n} \sum \left( 
+\deqn{ \sigma_{rs}^2 = \textstyle\frac{N}{n} \sum \left(
  \log \textstyle\frac{H_i}{C_i} \times \log \textstyle\frac{H_i}{O_i} + 
  \log \textstyle\frac{L_i}{C_i} \times \log \textstyle\frac{L_i}{O_i} 
  \right)


### PR DESCRIPTION
The volatility function in volatility.R includes a few equations under
"Details". Ideally, naming convention of the R functions and the
equations should match for better readability. The number of periods
per year was named N in the function but Z in the equations. The
comments in the volatility.R file were changed to make documentation
use the former. Commit includes the .Rd file made by roxygen2 5.0.1.