### PR TITLE
108 fix

### DIFF
--- a/R/runFun.R
+++ b/R/runFun.R
@@ -86,7 +86,7 @@ function(x, n=10, cumulative=FALSE) {
     result[beg:NROW(x)] <- cumsum(x[beg:NROW(x)])
 
     # Replace 1:(n-1) with NAs
-    is.na(result) <- c(1:(n-1+NAs))
+    is.na(result) <- c(0:(n-1+NAs))
   } else {
     # Call C routine
     result <- .Call("runsum", x, n, PACKAGE = "TTR")
@@ -126,7 +126,7 @@ function(x, n=10, cumulative=FALSE) {
     result[beg:NROW(x)] <- cummin(x[beg:NROW(x)])
 
     # Replace 1:(n-1) with NAs
-    is.na(result) <- c(1:(n-1+NAs))
+    is.na(result) <- c(0:(n-1+NAs))
   } else {
     # Call C routine
     result <- .Call("runmin", x, n, PACKAGE = "TTR")
@@ -170,7 +170,7 @@ function(x, n=10, cumulative=FALSE) {
     result[beg:NROW(x)] <- cummax(x[beg:NROW(x)])
 
     # Replace 1:(n-1) with NAs and prepend NAs from original data
-    is.na(result) <- c(1:(n-1+NAs))
+    is.na(result) <- c(0:(n-1+NAs))
   } else {
     # Call C routine
     result <- .Call("runmax", x, n, PACKAGE = "TTR")

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -125,10 +125,10 @@ test.runMedian.cumulative <- function() {
     }
   )
   base <- cummedian(input$all$Close)
+
   is.na(base) <- 1:4
   ttr <- runMedian(input$all$Close, 5, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
-  
   is.na(base) <- 1:5
   ttr <- runMedian(input$all$Close, 6, "mean", TRUE)
   checkEqualsNumeric(base, ttr)

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -56,9 +56,7 @@ test.runMin <- function() {
 test.runMin.cumulative <- function() {
   ttr <- runMin(input$all$Close, 1, TRUE)
   base <- cummin(input$all$Close)
-  checkEqualsNumeric(base, ttr)
-  ttr <- runMin(input$all$Close, 2, TRUE)
-  base <- cummin(input$all$Close)
+  is.na(base) <- 1
   checkEqualsNumeric(base, ttr)
 }
 
@@ -76,9 +74,6 @@ test.runMax <- function() {
 }
 test.runMax.cumulative <- function() {
   ttr <- runMax(input$all$Close, 1, TRUE)
-  base <- cummax(input$all$Close)
-  checkEqualsNumeric(base, ttr)
-  ttr <- runMax(input$all$Close, 2, TRUE)
   base <- cummax(input$all$Close)
   is.na(base) <- 1
   checkEqualsNumeric(base, ttr)
@@ -100,9 +95,6 @@ test.runMean.cumulative <- function() {
   ttr <- runMean(input$all$Close, 5, TRUE)
   base <- cumsum(input$all$Close) / seq_along(input$all$Close)
   is.na(base) <- 1:4
-  checkEqualsNumeric(base, ttr)
-  ttr <- runMean(input$all$Close, 1, TRUE)
-  base <- cumsum(input$all$Close) / seq_along(input$all$Close)
   checkEqualsNumeric(base, ttr)
 }
 
@@ -130,9 +122,6 @@ test.runMedian.cumulative <- function() {
     }
   )
   base <- cummedian(input$all$Close)
-  ttr <- runMedian(input$all$Close, 1, "mean", TRUE)
-  checkEqualsNumeric(base, ttr)
-
   is.na(base) <- 1:4
   ttr <- runMedian(input$all$Close, 5, "mean", TRUE)
   checkEqualsNumeric(base, ttr)

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -56,7 +56,6 @@ test.runMin <- function() {
 test.runMin.cumulative <- function() {
   ttr <- runMin(input$all$Close, 1, TRUE)
   base <- cummin(input$all$Close)
-  is.na(base) <- 1
   checkEqualsNumeric(base, ttr)
 }
 
@@ -75,7 +74,6 @@ test.runMax <- function() {
 test.runMax.cumulative <- function() {
   ttr <- runMax(input$all$Close, 1, TRUE)
   base <- cummax(input$all$Close)
-  is.na(base) <- 1
   checkEqualsNumeric(base, ttr)
 }
 
@@ -96,6 +94,11 @@ test.runMean.cumulative <- function() {
   base <- cumsum(input$all$Close) / seq_along(input$all$Close)
   is.na(base) <- 1:4
   checkEqualsNumeric(base, ttr)
+}
+test.runMean.cumulative.n.equals.1 <- function() {
+  n.1.cum <- runMean(1, n = 1, cumulative = T)
+  n.1.noncum <- runMean(1, n = 1, cumulative = F)
+  checkEqualsNumeric(n.1.cum, n.1.noncum)
 }
 
 
@@ -125,12 +128,10 @@ test.runMedian.cumulative <- function() {
   is.na(base) <- 1:4
   ttr <- runMedian(input$all$Close, 5, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
-
   is.na(base) <- 1:5
   ttr <- runMedian(input$all$Close, 6, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
 }
-
 test.runMedian.cumulative.leading.NA <- function() {
   na <- rep(NA, 10)
   x <- input$all$Close
@@ -138,6 +139,11 @@ test.runMedian.cumulative.leading.NA <- function() {
   y <- c(na, input$all$Close)
   ymed <- runMedian(y, 1, "mean", TRUE)
   checkEqualsNumeric(ymed, c(na, xmed))
+}
+test.runMedian.cumulative.n.equals.1 <- function() {
+  n.1.cum <- runMedian(1, n = 1, cumulative = T)
+  n.1.noncum <- runMedian(1, n = 1, cumulative = F)
+  checkEqualsNumeric(n.1.cum, n.1.noncum)
 }
 
 # Covariance

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -125,10 +125,10 @@ test.runMedian.cumulative <- function() {
     }
   )
   base <- cummedian(input$all$Close)
-
   is.na(base) <- 1:4
   ttr <- runMedian(input$all$Close, 5, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
+  
   is.na(base) <- 1:5
   ttr <- runMedian(input$all$Close, 6, "mean", TRUE)
   checkEqualsNumeric(base, ttr)

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -133,7 +133,6 @@ test.runMedian.cumulative <- function() {
   ttr <- runMedian(input$all$Close, 6, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
 }
-
 test.runMedian.cumulative.leading.NA <- function() {
   na <- rep(NA, 10)
   x <- input$all$Close

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -125,6 +125,7 @@ test.runMedian.cumulative <- function() {
     }
   )
   base <- cummedian(input$all$Close)
+
   is.na(base) <- 1:4
   ttr <- runMedian(input$all$Close, 5, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
@@ -132,6 +133,7 @@ test.runMedian.cumulative <- function() {
   ttr <- runMedian(input$all$Close, 6, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
 }
+
 test.runMedian.cumulative.leading.NA <- function() {
   na <- rep(NA, 10)
   x <- input$all$Close

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -125,7 +125,6 @@ test.runMedian.cumulative <- function() {
     }
   )
   base <- cummedian(input$all$Close)
-
   is.na(base) <- 1:4
   ttr <- runMedian(input$all$Close, 5, "mean", TRUE)
   checkEqualsNumeric(base, ttr)

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -96,8 +96,8 @@ test.runMean.cumulative <- function() {
   checkEqualsNumeric(base, ttr)
 }
 test.runMean.cumulative.n.equals.1 <- function() {
-  n.1.cum <- runMean(1, n = 1, cumulative = T)
-  n.1.noncum <- runMean(1, n = 1, cumulative = F)
+  n.1.cum <- runMean(1, n = 1, cumulative = TRUE)
+  n.1.noncum <- runMean(1, n = 1, cumulative = FALSE)
   checkEqualsNumeric(n.1.cum, n.1.noncum)
 }
 
@@ -128,10 +128,12 @@ test.runMedian.cumulative <- function() {
   is.na(base) <- 1:4
   ttr <- runMedian(input$all$Close, 5, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
+
   is.na(base) <- 1:5
   ttr <- runMedian(input$all$Close, 6, "mean", TRUE)
   checkEqualsNumeric(base, ttr)
 }
+
 test.runMedian.cumulative.leading.NA <- function() {
   na <- rep(NA, 10)
   x <- input$all$Close
@@ -141,8 +143,8 @@ test.runMedian.cumulative.leading.NA <- function() {
   checkEqualsNumeric(ymed, c(na, xmed))
 }
 test.runMedian.cumulative.n.equals.1 <- function() {
-  n.1.cum <- runMedian(1, n = 1, cumulative = T)
-  n.1.noncum <- runMedian(1, n = 1, cumulative = F)
+  n.1.cum <- runMedian(1, n = 1, cumulative = TRUE)
+  n.1.noncum <- runMedian(1, n = 1, cumulative = FALSE)
   checkEqualsNumeric(n.1.cum, n.1.noncum)
 }
 

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -59,6 +59,7 @@ test.runMin.cumulative <- function() {
   checkEqualsNumeric(base, ttr)
   ttr <- runMin(input$all$Close, 2, TRUE)
   base <- cummin(input$all$Close)
+  is.na(base) <- 1
   checkEqualsNumeric(base, ttr)
 }
 

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -59,7 +59,6 @@ test.runMin.cumulative <- function() {
   checkEqualsNumeric(base, ttr)
   ttr <- runMin(input$all$Close, 2, TRUE)
   base <- cummin(input$all$Close)
-  is.na(base) <- 1
   checkEqualsNumeric(base, ttr)
 }
 

--- a/inst/unitTests/runit.TTR.runFun.R
+++ b/inst/unitTests/runit.TTR.runFun.R
@@ -56,7 +56,9 @@ test.runMin <- function() {
 test.runMin.cumulative <- function() {
   ttr <- runMin(input$all$Close, 1, TRUE)
   base <- cummin(input$all$Close)
-  is.na(base) <- 1
+  checkEqualsNumeric(base, ttr)
+  ttr <- runMin(input$all$Close, 2, TRUE)
+  base <- cummin(input$all$Close)
   checkEqualsNumeric(base, ttr)
 }
 
@@ -74,6 +76,9 @@ test.runMax <- function() {
 }
 test.runMax.cumulative <- function() {
   ttr <- runMax(input$all$Close, 1, TRUE)
+  base <- cummax(input$all$Close)
+  checkEqualsNumeric(base, ttr)
+  ttr <- runMax(input$all$Close, 2, TRUE)
   base <- cummax(input$all$Close)
   is.na(base) <- 1
   checkEqualsNumeric(base, ttr)
@@ -95,6 +100,9 @@ test.runMean.cumulative <- function() {
   ttr <- runMean(input$all$Close, 5, TRUE)
   base <- cumsum(input$all$Close) / seq_along(input$all$Close)
   is.na(base) <- 1:4
+  checkEqualsNumeric(base, ttr)
+  ttr <- runMean(input$all$Close, 1, TRUE)
+  base <- cumsum(input$all$Close) / seq_along(input$all$Close)
   checkEqualsNumeric(base, ttr)
 }
 
@@ -122,6 +130,9 @@ test.runMedian.cumulative <- function() {
     }
   )
   base <- cummedian(input$all$Close)
+  ttr <- runMedian(input$all$Close, 1, "mean", TRUE)
+  checkEqualsNumeric(base, ttr)
+
   is.na(base) <- 1:4
   ttr <- runMedian(input$all$Close, 5, "mean", TRUE)
   checkEqualsNumeric(base, ttr)


### PR DESCRIPTION
runXXX functions were forcing the first value to always be NA when n = 1 and cumulative = T
when n =1, the first value should be the same, regardless of whether cumulative = T or cumulative = F
This was not an issue for n >1 and cumulative  = T

closes #108