### PR TITLE
refactor TR calcs into a discrete function

### DIFF
--- a/R/ADX.R
+++ b/R/ADX.R
@@ -76,8 +76,8 @@ function(HLC, n=14, maType, ...) {
   DMIp <- ifelse( dH==dL | (dH< 0 & dL< 0), 0, ifelse( dH >dL, dH, 0 ) )
   DMIn <- ifelse( dH==dL | (dH< 0 & dL< 0), 0, ifelse( dH <dL, dL, 0 ) )
 
-  TR    <- ATR(HLC)[,"tr"]
-  TRsum <- wilderSum(TR, n=n)
+  tr    <- TR(HLC)[,"tr"]
+  TRsum <- wilderSum(tr, n=n)
 
   DIp <- 100 * wilderSum(DMIp, n=n) / TRsum
   DIn <- 100 * wilderSum(DMIn, n=n) / TRsum

--- a/R/ATR.R
+++ b/R/ATR.R
@@ -61,7 +61,7 @@
 #' tr <- TR(ttrc[,c("High","Low","Close")])
 #' atr <- ATR(ttrc[,c("High","Low","Close")], n=14)
 #'
-#' @rdname TR
+#' @rdname ATR
 "TR" <-
 function(HLC) {
   # True Range

--- a/R/ATR.R
+++ b/R/ATR.R
@@ -17,6 +17,26 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+"TR" <- function(HLC) {
+  # True Range
+  HLC <- try.xts(HLC, error=as.matrix)
+  
+  if(is.xts(HLC)) {
+    closeLag <- lag.xts(HLC[,3])
+  } else {
+    closeLag <- c( NA, HLC[-NROW(HLC),3] )
+  }
+
+  trueHigh <- pmax( HLC[,1], closeLag, na.rm=FALSE )
+  trueLow  <- pmin( HLC[,2], closeLag, na.rm=FALSE )
+  tr       <- trueHigh - trueLow
+
+  result <- cbind(tr, trueHigh, trueLow )
+  colnames(result) <- c('tr','trueHigh','trueLow')
+  
+  reclass( result, HLC )
+}
+
 #'True Range / Average True Range
 #'
 #'True range (TR) is a measure of volatility of a High-Low-Close series;
@@ -58,6 +78,7 @@
 #'@examples
 #'
 #' data(ttrc)
+#' tr <- TR(ttrc[,c("High","Low","Close")])
 #' atr <- ATR(ttrc[,c("High","Low","Close")], n=14)
 #'
 "ATR" <-
@@ -66,16 +87,7 @@ function(HLC, n=14, maType, ...) {
   # Average True Range / True Range
 
   HLC <- try.xts(HLC, error=as.matrix)
-  
-  if(is.xts(HLC)) {
-    closeLag <- lag.xts(HLC[,3])
-  } else {
-    closeLag <- c( NA, HLC[-NROW(HLC),3] )
-  }
-
-  trueHigh <- pmax( HLC[,1], closeLag, na.rm=FALSE )
-  trueLow  <- pmin( HLC[,2], closeLag, na.rm=FALSE )
-  tr       <- trueHigh - trueLow
+  tr <- TR(HLC)
 
   maArgs <- list(n=n, ...)
   
@@ -88,9 +100,9 @@ function(HLC, n=14, maType, ...) {
     }
   }
 
-  atr <- do.call( maType, c( list(tr), maArgs ) )
+  atr <- do.call( maType, c( list(tr[,"tr"]), maArgs ) )
 
-  result <- cbind( tr, atr, trueHigh, trueLow )
+  result <- cbind( tr[,"tr"], atr, tr[,c("trueHigh", "trueLow")])
   colnames(result) <- c('tr','atr','trueHigh','trueLow')
   
   reclass( result, HLC )

--- a/R/ATR.R
+++ b/R/ATR.R
@@ -17,26 +17,6 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-"TR" <- function(HLC) {
-  # True Range
-  HLC <- try.xts(HLC, error=as.matrix)
-  
-  if(is.xts(HLC)) {
-    closeLag <- lag.xts(HLC[,3])
-  } else {
-    closeLag <- c( NA, HLC[-NROW(HLC),3] )
-  }
-
-  trueHigh <- pmax( HLC[,1], closeLag, na.rm=FALSE )
-  trueLow  <- pmin( HLC[,2], closeLag, na.rm=FALSE )
-  tr       <- trueHigh - trueLow
-
-  result <- cbind(tr, trueHigh, trueLow )
-  colnames(result) <- c('tr','trueHigh','trueLow')
-  
-  reclass( result, HLC )
-}
-
 #'True Range / Average True Range
 #'
 #'True range (TR) is a measure of volatility of a High-Low-Close series;
@@ -81,6 +61,26 @@
 #' tr <- TR(ttrc[,c("High","Low","Close")])
 #' atr <- ATR(ttrc[,c("High","Low","Close")], n=14)
 #'
+"TR" <- function(HLC) {
+  # True Range
+  HLC <- try.xts(HLC, error=as.matrix)
+  
+  if(is.xts(HLC)) {
+    closeLag <- lag.xts(HLC[,3])
+  } else {
+    closeLag <- c( NA, HLC[-NROW(HLC),3] )
+  }
+
+  trueHigh <- pmax( HLC[,1], closeLag, na.rm=FALSE )
+  trueLow  <- pmin( HLC[,2], closeLag, na.rm=FALSE )
+  tr       <- trueHigh - trueLow
+
+  result <- cbind(tr, trueHigh, trueLow )
+  colnames(result) <- c('tr','trueHigh','trueLow')
+  
+  reclass( result, HLC )
+}
+
 "ATR" <-
 function(HLC, n=14, maType, ...) {
 

--- a/R/ATR.R
+++ b/R/ATR.R
@@ -102,9 +102,9 @@ function(HLC, n=14, maType, ...) {
     }
   }
 
-  atr <- do.call( maType, c( list(tr[,"tr"]), maArgs ) )
+  atr <- do.call( maType, c( list(tr[,1]), maArgs ) )
 
-  result <- cbind( tr[,"tr"], atr, tr[,c("trueHigh", "trueLow")])
+  result <- cbind( tr[,1], atr, tr[,2:3])
   colnames(result) <- c('tr','atr','trueHigh','trueLow')
   
   reclass( result, HLC )

--- a/R/ATR.R
+++ b/R/ATR.R
@@ -61,6 +61,7 @@
 #' tr <- TR(ttrc[,c("High","Low","Close")])
 #' atr <- ATR(ttrc[,c("High","Low","Close")], n=14)
 #'
+#' @rdname TR
 "TR" <-
 function(HLC) {
   # True Range
@@ -83,6 +84,7 @@ function(HLC) {
   reclass( result, HLC )
 }
 
+#' @rdname ATR
 "ATR" <-
 function(HLC, n=14, maType, ...) {
 

--- a/R/ATR.R
+++ b/R/ATR.R
@@ -61,8 +61,8 @@
 #' tr <- TR(ttrc[,c("High","Low","Close")])
 #' atr <- ATR(ttrc[,c("High","Low","Close")], n=14)
 #'
-"TR" <- function(HLC) {
-
+"TR" <-
+function(HLC) {
   # True Range
   
   HLC <- try.xts(HLC, error=as.matrix)

--- a/R/ATR.R
+++ b/R/ATR.R
@@ -62,7 +62,9 @@
 #' atr <- ATR(ttrc[,c("High","Low","Close")], n=14)
 #'
 "TR" <- function(HLC) {
+
   # True Range
+  
   HLC <- try.xts(HLC, error=as.matrix)
   
   if(is.xts(HLC)) {


### PR DESCRIPTION
refactored  th, tl, tr calculations into its own reusable function
simplified ATR to call TR for underlying calculations, then pass to the averaging function
have kept output names and orders as close to existing functionality as possible. ATR output is identical to prior version

closes #114