### PR TITLE
Fix runMAD C-level segfault on NA centers

### DIFF
--- a/inst/tinytest/test-runfun.R
+++ b/inst/tinytest/test-runfun.R
@@ -257,6 +257,13 @@ y <- c(na, input$all$Close)
 ymed <- runMAD(y, 1, cumulative = TRUE)
 expect_equal(ymed, c(na, xmed))
 
+# runMAD with leading NA in center (Issue #25)
+x_test <- c(1:10)
+center_test <- c(NA, NA, 3:10)
+expect_silent( res <- runMAD(x_test, n = 3, center = center_test) )
+expect_true( all(is.na(res[1:4])) )
+expect_true( !any(is.na(res[5:10])) )
+
 # Percent Rank
 x <- input$all$Close
 expect_error( runPercentRank(x, 10, exact.multiplier = -0.1), info = "exact.multiplier bounds" )

--- a/inst/tinytest/test-runfun.R
+++ b/inst/tinytest/test-runfun.R
@@ -261,8 +261,8 @@ expect_equal(ymed, c(na, xmed))
 x_test <- c(1:10)
 center_test <- c(NA, NA, 3:10)
 expect_silent( res <- runMAD(x_test, n = 3, center = center_test) )
-expect_true( all(is.na(res[1:4])) )
-expect_true( !any(is.na(res[5:10])) )
+expect_true( all(is.na(res[1:2])) )
+expect_true( !any(is.na(res[3:10])) )
 
 # Percent Rank
 x <- input$all$Close

--- a/inst/tinytest/test-runfun.R
+++ b/inst/tinytest/test-runfun.R
@@ -258,11 +258,25 @@ ymed <- runMAD(y, 1, cumulative = TRUE)
 expect_equal(ymed, c(na, xmed))
 
 # runMAD with leading NA in center (Issue #25)
-x_test <- c(1:10)
-center_test <- c(NA, NA, 3:10)
-expect_silent( res <- runMAD(x_test, n = 3, center = center_test) )
-expect_true( all(is.na(res[1:2])) )
-expect_true( !any(is.na(res[3:10])) )
+# When center has more leading NAs than x, the C loop must not start until
+# both x AND center have valid data.
+#
+# DEMA(x, n=5) produces 8 leading NAs (2*n - 2 for the double smoothing).
+# With n=3 for runMAD, the old code only checked NAs in x (none), so it
+# started computing at index 3 and silently read center's NA values as
+# raw 0.0, producing wrong non-NA results for indices 3-8.
+# The fix makes the loop start at max(first_x + n - 1, first_center) = 9.
+x_dema <- as.numeric(input$all$Close[1:20])
+center_dema <- DEMA(x_dema, n = 5)
+dema_first_valid <- min(which(!is.na(center_dema)))  # should be 9
+
+res_dema <- runMAD(x_dema, n = 3, center = center_dema)
+# all indices before first valid center must be NA
+expect_true(all(is.na(res_dema[seq_len(dema_first_valid - 1)])),
+            info = "runMAD: NAs before center is valid (Issue #25)")
+# first valid result is at the DEMA's first non-NA position
+expect_true(!is.na(res_dema[dema_first_valid]),
+            info = "runMAD: first valid result aligns with center (Issue #25)")
 
 # Percent Rank
 x <- input$all$Close

--- a/src/runfun.c
+++ b/src/runfun.c
@@ -269,14 +269,24 @@ SEXP runmad(SEXP _x, SEXP _center, SEXP _n, SEXP _type,
   double *result = REAL(_result);
 
   /* check for non-leading NAs and get first non-NA location */
-  SEXP _first = PROTECT(xts_na_check(_x, ScalarLogical(TRUE))); P++;
-  int first = INTEGER(_first)[0];
-  if (n + first > nr) {
+  SEXP _first_x = PROTECT(xts_na_check(_x, ScalarLogical(TRUE))); P++;
+  int first_x = INTEGER(_first_x)[0];
+  if (n + first_x > nr) {
     error("not enough non-NA values in 'x'");
   }
 
+  SEXP _first_center = PROTECT(xts_na_check(_center, ScalarLogical(TRUE))); P++;
+  int first_center = INTEGER(_first_center)[0];
+  /* runMAD does not necessarily need n + first_center > nr because center doesn't need a lookback window itself here, 
+     but there must be enough values to calculate the deviation */
+  if (first_center >= nr) {
+    error("not enough non-NA values in 'center'");
+  }
+
+  int first = (first_x > first_center) ? first_x : first_center;
+
   /* Set leading NAs in output */
-  for (i = 0; i < first + n; i++) {
+  for (i = 0; i < first + n - 1; i++) {
     result[i] = NA_REAL;
   }
 

--- a/src/runfun.c
+++ b/src/runfun.c
@@ -283,10 +283,11 @@ SEXP runmad(SEXP _x, SEXP _center, SEXP _n, SEXP _type,
     error("not enough non-NA values in 'center'");
   }
 
-  int first = (first_x > first_center) ? first_x : first_center;
+  int first_i_x = first_x + n - 1;
+  int first_i = (first_i_x > first_center) ? first_i_x : first_center;
 
   /* Set leading NAs in output */
-  for (i = 0; i < first + n - 1; i++) {
+  for (i = 0; i < first_i; i++) {
     result[i] = NA_REAL;
   }
 
@@ -303,7 +304,6 @@ SEXP runmad(SEXP _x, SEXP _center, SEXP _n, SEXP _type,
 
   SEXP _window;
   double *window;
-  int first_i = first + n - 1;
 
   if (cumulative) {
     _window = PROTECT(duplicate(_x)); P++;
@@ -311,7 +311,7 @@ SEXP runmad(SEXP _x, SEXP _center, SEXP _n, SEXP _type,
 
     if (type) {
       for (i = first_i; i < nr; i++) {
-        int N = i-first+1;
+        int N = i-first_x+1;
         for (j = 0; j < N; j++) {
           window[j] = fabs(x[i-j] - center[i]);
         }


### PR DESCRIPTION
Fixes #25

### Description
This PR fixes a severe C-level `NA/NaN/Inf in foreign function call` segfault that occurs when a highly smoothed moving average (like `DEMA`) is passed into the `center` argument of `runMAD`.

Because `DEMA` contains significant leading `NA`s, and the internal `.Call(C_runmad, ...)` previously only checked for leading `NA`s in `x` (and completely ignored the `NA` state of `center`), the C loop would attempt floating point operations on raw memory before the `center` vector had valid data.

### Reproducible Example
```r
library(TTR)
x <- 1:10
center_with_na <- c(NA, NA, 3:10)

# This causes a C-level segfault without the patch
runMAD(x, n = 3, center = center_with_na)
